### PR TITLE
feat: enable recommended nginx settings

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -59,6 +59,10 @@
   security.sudo.enable = true;
 
   services.nginx.enable = true;
+  services.nginx.recommendedGzipSettings = true;
+  services.nginx.recommendedOptimisation = true;
+  services.nginx.recommendedProxySettings = true;
+  services.nginx.recommendedTlsSettings = true;
   services.nginx.sslProtocols = "TLSv1.3";
   services.nginx.sslCiphers = lib.concatStringsSep ":" [
     "ECDHE-ECDSA-AES256-GCM-SHA384"
@@ -67,7 +71,6 @@
   ];
   services.nginx.appendHttpConfig = ''
     proxy_ssl_protocols TLSv1.3;
-    ssl_prefer_server_ciphers on;
   '';
 
   services.openssh.enable = true;


### PR DESCRIPTION
Enable the recommended nginx SSL config from https://ssl-config.mozilla.org/#server=nginx&config=intermediate as well as some optimisations and useful proxy headers

See https://github.com/NixOS/nixpkgs/blob/6300cde54545835c4948f2b7bee376a8c246b26f/nixos/modules/services/web-servers/nginx/default.nix#L115-L168
https://github.com/NixOS/nixpkgs/blob/6300cde54545835c4948f2b7bee376a8c246b26f/nixos/modules/services/web-servers/nginx/default.nix#L59-L66