### PR TITLE
feat: do not force HTTPS on Benefice

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -215,8 +215,8 @@
                   networking.firewall.enable = lib.mkForce false;
 
                   services.nginx.virtualHosts.${fqdn} = {
+                    addSSL = true;
                     enableACME = true;
-                    forceSSL = true;
                     locations."/".proxyPass = "http://localhost:3000";
                   };
 


### PR DESCRIPTION
This is required to allow TCP connections to demo workloads until we have a better solution (dedicated IP/FQDN)