### PR TITLE
revert: "feat: do not force HTTPS on Benefice"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -215,8 +215,8 @@
                   networking.firewall.enable = lib.mkForce false;
 
                   services.nginx.virtualHosts.${fqdn} = {
-                    addSSL = true;
                     enableACME = true;
+                    forceSSL = true;
                     locations."/".proxyPass = "http://localhost:3000";
                   };
 


### PR DESCRIPTION
Reverts profianinc/staging#26

`nginx` only listens on 80 and 443, so this has nothing to do with the workloads